### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,9 @@ https://github.com/beecho01/material-symbols
 - Open your "configuration.yaml" via File editor or other means.
 - Add the following, save and restart Home Assistant.
 ```
-lovelace:
-  mode: yaml
-  resources:
-    - url: /hacsfiles/material-symbols/material-symbols.js
-      type: module
+frontend:
+  extra_module_url:
+    - /hacsfiles/material-symbols/material-symbols.js
 ```
   
 ### Manual:
@@ -104,7 +102,7 @@ type: entities
 entities:
   - entity: switch.tv_smart_plug
     name: My TV
-    icon: m3s:switches-outlined
+    icon: m3s:volume-off-outlined
 ```
 
 ---


### PR DESCRIPTION
I appear to have solved the #4 problem (at least on my end), and I think it is because the README instructions are wrong and there isn't something else going on with the code per se.

I believe this part

lovelace:
  mode: yaml
  resources:
    - url: /hacsfiles/material-symbols/material-symbols.js
      type: module
should be replaced with

frontend:
  extra_module_url:
    - /hacsfiles/material-symbols/material-symbols.js
as modifying lovelace to yaml mode causes all sorts of issues + needs the creation and reference of a ui-lovelace.yaml file as per [the official documentation](https://fonts.google.com/icons?icon.platform=android). Also I don't see any reason why it was different than the referenced [hass-hue-icons](https://github.com/arallsopp/hass-hue-icons) project in the first place

Also, the provided test icon m3s:switches-outlined does not exist in the material-symbols.js, so I suggest to change it to one that exists like m3s:volume-off-outlined.

Lastly the provided directory is laggy and slow. I propose to direct users to copy the icons code from [google's official source](https://fonts.google.com/icons?icon.platform=android) until fixed (I know not all Google icons are present in the integration - example the switches one - but I think it is better for now).

I have forked the project and proposed the changes.